### PR TITLE
Added code to respect whitespace trimming flags

### DIFF
--- a/render/render.go
+++ b/render/render.go
@@ -46,7 +46,9 @@ func (n *BlockNode) render(w *trimWriter, ctx nodeContext) Error {
 	if renderer == nil {
 		panic(fmt.Errorf("unset renderer for %v", n))
 	}
+	w.TrimLeft(n.TrimLeft)
 	err := renderer(w, rendererContext{ctx, nil, n})
+	w.TrimRight(n.TrimRight)
 	return wrapRenderError(err, n)
 }
 


### PR DESCRIPTION
This fix appears to address the whitespace issue in "blocks" (for statements and if statements).

Merging it here in case the upstream PR takes a while to merge and release:
Issue: https://github.com/osteele/liquid/issues/79
PR: https://github.com/osteele/liquid/pull/78